### PR TITLE
fix: factory_bot_railsの階層をproductionでも参照できるように修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,10 +33,12 @@ gem 'rack-cors'
 # JSON serializer
 gem 'alba'
 
+# factory_bot
+gem 'factory_bot_rails'
+
 group :development, :test do
   gem 'debug', platforms: %i[mri mingw x64_mingw]
   gem 'rspec-rails', '~> 6.0.0'
-  gem 'factory_bot_rails'
   gem 'dotenv-rails'
   gem 'rubocop'
   gem 'rubocop-rails'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,5 @@
+require 'factory_bot_rails'
+
 3.times.each do
   admin_user = FactoryBot.create(:user, :user_with_teams)
   4.times.each do


### PR DESCRIPTION
本番環境の初期データ投入用にfactory_bot_railsを参照できるように修正。
ただし悪手な可能性があるため、seed_fuなど他Gemで代替可能とした方が良いと考えています。