### PR TITLE
fix: jwtのencode,decode時にcredentialsを利用するように修正

### DIFF
--- a/app/models/concerns/jwt_token.rb
+++ b/app/models/concerns/jwt_token.rb
@@ -3,7 +3,7 @@ module JwtToken
 
   class_methods do
     def decode(token)
-      JWT.decode token, Rails.application.secrets.secret_key_base
+      JWT.decode token, Rails.application.credentials.secret_key_base
     end
   end
 
@@ -15,6 +15,6 @@ module JwtToken
   private
 
   def issue_token(payload)
-    JWT.encode payload, Rails.application.secrets.secret_key_base
+    JWT.encode payload, Rails.application.credentials.secret_key_base
   end
 end


### PR DESCRIPTION
JWTのエンコード、デコード時に利用するシークレット情報がnilとなっていたことが考えられるため、変更。
fly.ioにデプロイし、認証処理が正常に行えることを確認済みのためマージします。