### PR TITLE
fix: fly.ioのドキュメントを参考に、Redis切断時の記述を追加

### DIFF
--- a/config/initializers/action_cable.rb
+++ b/config/initializers/action_cable.rb
@@ -1,0 +1,20 @@
+# Restart Action Cable server on Redis connection failures.
+# See: https://github.com/rails/rails/pull/45478
+require 'action_cable/subscription_adapter/redis'
+
+module ActionCableRedisListenerPatch
+  private
+
+  def ensure_listener_running
+    @thread ||= Thread.new do
+      Thread.current.abort_on_exception = true
+      conn = @adapter.redis_connection_for_subscriptions
+      listen conn
+    rescue ::Redis::BaseConnectionError
+      @thread = @raw_client = nil
+      ::ActionCable.server.restart
+    end
+  end
+end
+
+ActionCable::SubscriptionAdapter::Redis::Listener.prepend(ActionCableRedisListenerPatch)


### PR DESCRIPTION
https://fly.io/docs/rails/getting-started/#patching-action-cable-to-handle-redis-timeouts
「patching-action-cable-to-handle-redis-timeouts」の項を参考にタイムアウトした際のパッチを追加