### PR TITLE
fix: 設定漏れのイベントを追加

### DIFF
--- a/app/channels/workshop_channel.rb
+++ b/app/channels/workshop_channel.rb
@@ -38,6 +38,14 @@ class WorkshopChannel < ApplicationCable::Channel
     ActionCable.server.broadcast("workshop:#{params[:room]}", content)
   end
 
+  def delete_post
+    content = {
+      type: 'delete_post',
+      body: {}
+    }
+    ActionCable.server.broadcast("workshop:#{params[:room]}", content)
+  end
+
   def end_workshop
     content = {
       type: 'end_workshop',


### PR DESCRIPTION
投稿の削除時にチャネルでのイベント配信が漏れていたため、追加いたしました。